### PR TITLE
add json tag for links struct

### DIFF
--- a/pagination.go
+++ b/pagination.go
@@ -10,7 +10,7 @@ type PagedData[T any] struct {
 	Links struct {
 		Prev string `json:"prev"`
 		Next string `json:"next"`
-	}
+	} `json:"links"`
 }
 
 type PaginationParams struct {


### PR DESCRIPTION
This pull request includes a change to the `pagination.go` file to improve the JSON serialization of the `PagedData` struct.

Improvements to JSON serialization:

* [`pagination.go`](diffhunk://#diff-d8cd763ba22bff5feaa19cc4d120d2f448a689d67a7ec63e5c0536381aa04f7eL13-R13): Modified the `Links` struct within `PagedData` to include a JSON tag for the entire struct, ensuring it is serialized under the "links" key.